### PR TITLE
edlib: Fix infinite loop on EOF

### DIFF
--- a/edlib.c
+++ b/edlib.c
@@ -77,6 +77,9 @@
 
 DAS_ARRAY_T *buffer = 0;
 
+/* External variables */
+extern int exiting;
+
 /* functions */
 
 #ifndef __STDC__
@@ -403,6 +406,8 @@ read_line (char *prompt)
     }
   while (c != EOF && c != '\n');
 #endif /* SHIFT_JIS */
+  if (c == EOF)
+    exiting = 1;
   return DScstr (ds);
 }
 


### PR DESCRIPTION
When running on non-DOS (e.g. Linux), if you hit ^D, it generates EOF. Right now, edlin goes into an infinite loop.

This patch causes an EOF receipt to cause edlin to exit gracefully, which also makes it scriptable:

```
lhh@fedora:~/tmp/edlin$ cat tmp.txt 
a
hello, world!
.
w
lhh@fedora:~/tmp/edlin$ cat tmp.txt | ./edlin hi.txt
edlin 2.10c, copyright (c) 2003 Gregory Pietsch
This program comes with ABSOLUTELY NO WARRANTY.
It is free software, and you are welcome to redistribute it
under the terms of the GNU General Public License -- either
version 2 of the license, or, at your option, any later
version.

hi.txt: 0 lines read
* :  : *hi.txt: 1 line written
*lhh@fedora:~/tmp/edlin$ cat hi.txt
hello, world!
```
